### PR TITLE
Use pkg-config to detect libopusenc

### DIFF
--- a/.github/actions/container/Dockerfile
+++ b/.github/actions/container/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:slim-bookworm
 
-RUN apt-get update && apt-get install -y libclang-dev libopusenc-dev
+RUN apt-get update && apt-get install -y libclang-dev libopusenc-dev pkg-config
 RUN rustup component add clippy rustfmt
 
 ENTRYPOINT ["sh", "-c"]

--- a/opusenc-sys/Cargo.toml
+++ b/opusenc-sys/Cargo.toml
@@ -13,4 +13,5 @@ links = "opusenc"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.69.2"
+bindgen = "0.72.1"
+pkg-config = "0.3.32"

--- a/opusenc-sys/build.rs
+++ b/opusenc-sys/build.rs
@@ -4,9 +4,19 @@ fn main() {
     println!("cargo:rustc-link-lib=opusenc");
     println!("cargo:rerun-if-changed=wrapper.h");
 
+    let library = pkg_config::Config::new()
+        .atleast_version("0.2")
+        .probe("libopusenc")
+        .expect("unable to find libopusenc library using pkg-config");
+
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
-        .clang_args(["-isystem", "/usr/include/opus"])
+        .clang_args(
+            library
+                .include_paths
+                .iter()
+                .map(|path| format!("-I{}", path.to_string_lossy())),
+        )
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
         .generate()

--- a/opusenc-sys/wrapper.h
+++ b/opusenc-sys/wrapper.h
@@ -1,2 +1,2 @@
-#include <opus/opus_defines.h>
-#include <opus/opusenc.h>
+#include "opus_defines.h"
+#include "opusenc.h"


### PR DESCRIPTION
Alternative to https://github.com/d-k-bo/opusenc-rs/pull/6. Instead of hardcoding any include paths, the include path is found using `pkg-config`.

Closes #4, closes #5, closes #6, closes #7.